### PR TITLE
Hide reservations tab for admin users

### DIFF
--- a/src/features/profile/profile-shell/ProfileShell.jsx
+++ b/src/features/profile/profile-shell/ProfileShell.jsx
@@ -14,7 +14,12 @@ import ProfileSettings from '../profile-settings/ProfileSettings';
 const ALL_TABS = [
   { id: 'general-details', label: 'General Details', component: ProfileGeneralDetails },
   { id: 'employee-availability', label: 'Availability', component: ProfileAvailabilityList, roles: ['EMPLOYEE'] },
-  { id: 'reservations', label: 'Reservations', component: ProfileReservationList },
+  {
+    id: 'reservations',
+    label: 'Reservations',
+    component: ProfileReservationList,
+    hideForRoles: ['TENANT_ADMIN', 'ADMIN']
+  },
   { id: 'settings', label: 'Settings', component: ProfileSettings }
 ];
 
@@ -26,8 +31,10 @@ const ProfileShell = () => {
   const [loading, setLoading] = useState(false);
 
   // Filter tabs based on user role
-  const availableTabs = ALL_TABS.filter(tab => 
-    !tab.roles || tab.roles.includes(user?.role)
+  const availableTabs = ALL_TABS.filter(
+    (tab) =>
+      (!tab.roles || tab.roles.includes(user?.role)) &&
+      (!tab.hideForRoles || !tab.hideForRoles.includes(user?.role))
   );
 
   // Find current tab index


### PR DESCRIPTION
## Summary
- exclude TENANT_ADMIN and ADMIN roles from viewing the Reservations profile tab

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_68a7a8f7f4ac832c95b7cd25b967dc1a