### PR TITLE
Hide preview tenant button for admins

### DIFF
--- a/src/features/profile/profile-shell/ProfileShell.jsx
+++ b/src/features/profile/profile-shell/ProfileShell.jsx
@@ -64,15 +64,17 @@ const ProfileShell = () => {
 
   return (
     <div>
-      <div className="w-full px-3 h-16 flex justify-end items-center">
-              <Button
-                variant="outlined"
-                startIcon={<PreviewIcon />}
-                onClick={() => navigate(`/tenant/${tenantKey}/view`)}
-              >
-                Preview Tenant
-              </Button>
-            </div>
+      {user?.role !== 'ADMIN' && (
+        <div className="w-full px-3 h-16 flex justify-end items-center">
+          <Button
+            variant="outlined"
+            startIcon={<PreviewIcon />}
+            onClick={() => navigate(`/tenant/${tenantKey}/view`)}
+          >
+            Preview Tenant
+          </Button>
+        </div>
+      )}
     <Box sx={{ display: 'flex', minHeight: 400, bgcolor: '#f5f5f5', p: 3 }}>
       <Paper elevation={2} sx={{ minWidth: 220, mr: 3 }}>
         <Tabs


### PR DESCRIPTION
## Summary
- Hide the Profile page's "Preview Tenant" button when an admin is logged in

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom' from 'src/routes/AppRouter.jsx')*


------
https://chatgpt.com/codex/tasks/task_e_68a7aaa70314832cb618249409b26b24