### PR TITLE
feat: toggle tenant activation

### DIFF
--- a/src/features/tenant/services/tenantService.js
+++ b/src/features/tenant/services/tenantService.js
@@ -32,6 +32,24 @@ export const getTenants = async (token) => {
   return response.data;
 };
 
+export const activateTenantById = async (id, token) => {
+  const response = await axios.post(`${API_URL}/tenants/${id}/activate`, null, {
+    headers: {
+      'Authorization': `Bearer ${token}`,
+    },
+  });
+  return response.data;
+};
+
+export const deactivateTenantById = async (id, token) => {
+  const response = await axios.delete(`${API_URL}/tenants/${id}`, {
+    headers: {
+      'Authorization': `Bearer ${token}`,
+    },
+  });
+  return response.data;
+};
+
 export const getTenantByKey = async (tenantKey, token) => {
   const response = await axios.get(`${API_URL}/tenants/key/${tenantKey}`, {
       headers: {
@@ -81,3 +99,4 @@ export const updateTenant = async (tenantData, tenantKey, token) => {
   });
   return response.data;
 };
+


### PR DESCRIPTION
## Summary
- add admin API helpers to activate and deactivate tenants
- expose activate/deactivate actions in tenant table

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom' from 'src/routes/AppRouter.jsx')*


------
https://chatgpt.com/codex/tasks/task_e_68a7adda6018832c93dfa18863969e0f