### PR TITLE
Show backend login error messages

### DIFF
--- a/src/features/auth/pages/Login.jsx
+++ b/src/features/auth/pages/Login.jsx
@@ -58,7 +58,8 @@ const Login = () => {
       !response.tenantExists ? navigate('/tenant/form') : navigate(`/tenant/${response.tenantKey}/view`);
     } catch (err) {
       console.error('Login failed', err);
-      setError('Login failed');
+      const message = err.response?.data?.message || err.message || 'Login failed';
+      setError(message);
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
## Summary
- display server-provided error message when login fails

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom' from 'src/routes/AppRouter.jsx')*

------
https://chatgpt.com/codex/tasks/task_e_68a7b4691ae0832c913cce30dd20e8e0