### PR TITLE
Avoid sending unchanged tenant images during update

### DIFF
--- a/src/features/tenant/services/tenantService.js
+++ b/src/features/tenant/services/tenantService.js
@@ -79,10 +79,15 @@ export const getTenantMe = async (token) => {
 };
 
 export const updateTenant = async (tenantData, tenantKey, token) => {
-  
+
   const formData = new FormData();
 
   Object.entries(tenantData).forEach(([key, value]) => {
+    // Skip existing image URLs for logo and coverPicture
+    if ((key === 'logo' || key === 'coverPicture') && !(value instanceof File)) {
+      return;
+    }
+
     if (value instanceof File || typeof value === 'string') {
       formData.append(key, value);
     } else if (typeof value === 'object' && value !== null) {


### PR DESCRIPTION
## Summary
- Skip logo and coverPicture fields in update payload when they are existing URLs

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom')*
- `npm run build` *(fails: Unexpected '/' from Css Minimizer plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68c1985c9950832c910ca573bc1fd350