### PR TITLE
Normalize TikTok and Instagram links in tenant profiles

### DIFF
--- a/src/features/tenant/pages/tenant-form/TenantForm.jsx
+++ b/src/features/tenant/pages/tenant-form/TenantForm.jsx
@@ -10,6 +10,7 @@ import EmployeeServicesSection from './EmployeeServicesSection';
 import ThemeSettingsSection from './ThemeSettingsSection';
 import Button from '@mui/material/Button';
 import { useAuth } from '../../../auth/context/AuthContext';
+import { formatSocialUrl } from '../../../../shared/utils/urlUtils';
 
 const TenantForm = () => {
   const navigate = useNavigate();
@@ -70,8 +71,8 @@ const TenantForm = () => {
       motto: data.tenantInfo.motto,
       address: data.location.address,
       phone: data.tenantInfo.phone,
-      tiktok: data.tenantInfo.tiktok,
-      instagram: data.tenantInfo.instagram,
+      tiktok: formatSocialUrl(data.tenantInfo.tiktok, 'tiktok'),
+      instagram: formatSocialUrl(data.tenantInfo.instagram, 'instagram'),
       textColour: data.themeSettings.textColor,
       backgroundColour: data.themeSettings.backgroundColor,
       borderColour: data.themeSettings.borderColor,

--- a/src/features/tenant/pages/tenant-settings/TenantSettingsGeneralDetails.jsx
+++ b/src/features/tenant/pages/tenant-settings/TenantSettingsGeneralDetails.jsx
@@ -16,6 +16,7 @@ import { updateTenant, getTenantByKey } from '../../services/tenantService';
 import ImageUpload from '../../../../shared/components/ImageUpload';
 import { useParams } from 'react-router-dom';
 import { useAuth } from '../../../auth/context/AuthContext';
+import { formatSocialUrl } from '../../../../shared/utils/urlUtils';
 
 const fontFamilies = [
   'Roboto',
@@ -103,8 +104,8 @@ const TenantSettingsGeneralDetails = () => {
     motto: formData.motto,
     description: formData.description,
     phone: formData.phone,
-    tiktok: formData.tiktok,
-    instagram: formData.instagram,
+    tiktok: formatSocialUrl(formData.tiktok, 'tiktok'),
+    instagram: formatSocialUrl(formData.instagram, 'instagram'),
     address: formData.address,
     textColour: formData.textColor,
     backgroundColour: formData.backgroundColor,

--- a/src/features/tenant/pages/tenant-view/TenantView.jsx
+++ b/src/features/tenant/pages/tenant-view/TenantView.jsx
@@ -12,7 +12,7 @@ import {
 import { AiFillTikTok } from 'react-icons/ai';
 import { CiInstagram } from 'react-icons/ci';
 import { useNavigate, useOutletContext, useParams } from 'react-router-dom';
-import { toPublicUrl } from '../../../../shared/utils/urlUtils';
+import { toPublicUrl, formatSocialUrl } from '../../../../shared/utils/urlUtils';
 import { BASE_URL } from '../../../../shared/api';
 import { useAuth } from '../../../auth/context/AuthContext';
 
@@ -59,6 +59,8 @@ const TenantView = () => {
   const data = tenant || fallbackTenant;
   const coverUrl = toPublicUrl(data.coverPictureUrl, BASE_URL);
   const logoUrl = toPublicUrl(data.logoUrl, BASE_URL);
+  const tiktokUrl = formatSocialUrl(data.tiktok, 'tiktok');
+  const instagramUrl = formatSocialUrl(data.instagram, 'instagram');
 
 
   return (
@@ -162,11 +164,11 @@ const TenantView = () => {
               <Typography variant="body1" sx={{ my: 2 }}>
                 {data.description}
               </Typography>
-              {(data.tiktok || data.instagram) && (
+              {(tiktokUrl || instagramUrl) && (
                 <Box sx={{ display: 'flex', gap: 2, mt: 1 }}>
-                  {data.tiktok && (
+                  {tiktokUrl && (
                     <Button
-                      href={data.tiktok}
+                      href={tiktokUrl}
                       target="_blank"
                       startIcon={<AiFillTikTok />}
                       sx={{ textTransform: 'none' }}
@@ -174,9 +176,9 @@ const TenantView = () => {
                       TikTok
                     </Button>
                   )}
-                  {data.instagram && (
+                  {instagramUrl && (
                     <Button
-                      href={data.instagram}
+                      href={instagramUrl}
                       target="_blank"
                       startIcon={<CiInstagram />}
                       sx={{ textTransform: 'none' }}

--- a/src/shared/utils/urlUtils.js
+++ b/src/shared/utils/urlUtils.js
@@ -11,3 +11,20 @@ export function toPublicUrl(filePath, baseUrl) {
   return `${baseUrl}${normalized}`;
 }
 
+export function formatSocialUrl(url, platform) {
+  if (!url) return '';
+  let trimmed = url.trim();
+  if (/^https?:\/\//i.test(trimmed)) return trimmed;
+  if (trimmed.includes('tiktok.com') || trimmed.includes('instagram.com')) {
+    return `https://${trimmed.replace(/^https?:\/\//i, '')}`;
+  }
+  trimmed = trimmed.replace(/^@/, '');
+  if (platform === 'tiktok') {
+    return `https://www.tiktok.com/@${trimmed}`;
+  }
+  if (platform === 'instagram') {
+    return `https://www.instagram.com/${trimmed}`;
+  }
+  return trimmed;
+}
+


### PR DESCRIPTION
## Summary
- ensure TikTok and Instagram URLs resolve to full paths
- normalize social URLs in tenant creation and settings forms

## Testing
- `npm test --silent -- --watchAll=false` *(fails: Cannot find module 'react-router-dom')*


------
https://chatgpt.com/codex/tasks/task_e_68c1a4936d24832c8a2a78bd9f04d66d