### PR TITLE
Route pricing Get Started buttons to registration

### DIFF
--- a/src/shared/components/landing-pages/Pricing.jsx
+++ b/src/shared/components/landing-pages/Pricing.jsx
@@ -1,7 +1,9 @@
 import { useTranslation } from "react-i18next";
+import { useNavigate } from "react-router-dom";
 
 const Pricing = () => {
   const { t } = useTranslation();
+  const navigate = useNavigate();
 
   const plans = [
     { 
@@ -105,11 +107,14 @@ const Pricing = () => {
                 ))}
               </ul>
               
-              <button className={`mt-8 w-full py-3 px-6 rounded-lg font-medium ${
-                plan.popular 
-                  ? "bg-blue-600 text-white hover:bg-blue-700" 
+              <button
+                className={`mt-8 w-full py-3 px-6 rounded-lg font-medium ${
+                plan.popular
+                  ? "bg-blue-600 text-white hover:bg-blue-700"
                   : "bg-gray-100 text-gray-800 hover:bg-gray-200"
-              }`}>
+              }`}
+                onClick={() => navigate('/register')}
+              >
                 {t("PRICING.CTA")}
               </button>
             </div>


### PR DESCRIPTION
## Summary
- Use `useNavigate` in pricing section to handle button navigation
- Link all pricing "Get Started" buttons to the registration route, matching the "Become a Tenant" path

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom' from 'src/routes/AppRouter.jsx')*

------
https://chatgpt.com/codex/tasks/task_e_68c1aaa7b03c832c85e16ce210a39557